### PR TITLE
Restricts registrant age

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -44,7 +44,7 @@ class RegistrationsController < ApplicationController
 
     @nid = NidApi.get(nid)
 
-    if @nid
+    if @nid && age_allowed?(@nid["birth_date"])
       session[:nid] = @nid
       redirect_to confirmnid_registration_path
     else
@@ -126,6 +126,10 @@ class RegistrationsController < ApplicationController
   end
 
   private
+
+  def age_allowed?(birthdate)
+    Date.parse(birthdate) < (::SETTINGS[:voter_registration_deadline] - 18.years)
+  end
 
   def attempts_allowed_without_captcha
     2

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -184,6 +184,26 @@ describe RegistrationsController do
           post :findnid, :nid => nid, :nid_confirmation => nid
       end
 
+      context "if age 18 or under" do
+        before do
+          underage_response = successful_response
+          underage_response[:body]["birth_date"] = "2000-01-01T00:00:00"
+
+          stub_request(:get, uri).
+            to_return(underage_response)
+
+          post :findnid, :nid => nid, :nid_confirmation => nid
+        end
+
+        it "rerenders form" do
+          assert_template :new
+        end
+
+        it "should display error message" do
+          assert_not_nil assigns(:not_found)
+        end
+      end
+
       context "if nid not found" do
         before do
           NidApi.stub(:get)


### PR DESCRIPTION
Requires registrants to be 18+ by registration deadline in order to successfully register their nid
